### PR TITLE
Change default search algorithm from DFS to BFS

### DIFF
--- a/search.py
+++ b/search.py
@@ -1,8 +1,9 @@
 import pickle
 import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
-
 from requests.exceptions import ConnectionError
+
+from credentials import client_id, client_secret
 
 
 class NetworkMiner():
@@ -14,9 +15,11 @@ class NetworkMiner():
         max_pop_size=100,
         min_popularity=65,
         verbose=True,
+        client_id=client_id,
+        client_secret=client_secret,
     ):
-        # Object to interface with Spotify interface
-        self.scrapper = self._setup_scrapper()
+        # Object to interface with Spotify API
+        self.scrapper = self._setup_scrapper(client_id, client_secret)
 
         # Search paremeters
         self.include_collaborators=include_collaborators
@@ -26,12 +29,9 @@ class NetworkMiner():
         self.verbose=verbose
 
 
-    def _setup_scrapper(self):
+    def _setup_scrapper(self, CLIENT_ID, CLIENT_SECRET):
         """Initialize Spotify object with proper authentification."""
-
-        from credentials import CLIENT_ID, CLIENT_SECRET
-
-        client_credentials_manager = SpotifyClientCredentials(CLIENT_ID, CLIENT_SECRET)
+        client_credentials_manager = SpotifyClientCredentials(client_id, client_secret)
         spotify = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
 
         return spotify

--- a/search.py
+++ b/search.py
@@ -98,7 +98,7 @@ class NetworkMiner():
             if self.verbose:
                 # Verbose output: "Node <NUMBER>: <ARTIST> (<POPULARITY>)"
                 msg = "Node {}: {} (popularity = {})".format(
-                    len(metadata.keys()),
+                    len(explored),
                     metadata[uri]['name'],
                     metadata[uri]['popularity']
                 )
@@ -146,6 +146,14 @@ class NetworkMiner():
                 # 4. Add the artist's uri to the set of explored artists and to the queue
                 explored.add(artist['uri'])
                 queue.append(artist['uri'])
+                if self.verbose:
+                    # Verbose output: "Node <NUMBER>: <ARTIST> (<POPULARITY>)"
+                    msg = "Node {}: {} (popularity = {})".format(
+                        len(explored),
+                        metadata[related_artist_uri]['name'],
+                        metadata[related_artist_uri]['popularity']
+                    )
+                    print(msg)
 
                 # 5. Check if the max_pop_size has been hit
                 if len(explored) == self.max_pop_size:

--- a/search.py
+++ b/search.py
@@ -22,12 +22,11 @@ class NetworkMiner():
         self.scrapper = self._setup_scrapper(client_id, client_secret)
 
         # Search paremeters
-        self.include_collaborators=include_collaborators
-        self.breadth_limit=breadth_limit
-        self.max_pop_size=max_pop_size
-        self.min_popularity=min_popularity
-        self.verbose=verbose
-
+        self.include_collaborators = include_collaborators
+        self.breadth_limit = breadth_limit
+        self.max_pop_size = max_pop_size
+        self.min_popularity = min_popularity
+        self.verbose = verbose
 
     def _setup_scrapper(self, CLIENT_ID, CLIENT_SECRET):
         """Initialize Spotify object with proper authentification."""
@@ -35,7 +34,6 @@ class NetworkMiner():
         spotify = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
 
         return spotify
-
 
     def _get_artist_metadata(self, uri, attributes):
         """Return well formatted metadata. Fields of interest are specified in `attributes`."""
@@ -52,7 +50,6 @@ class NetworkMiner():
                 print("{} is not a valid key".format(attr))
 
         return artist_metadata
-
 
     def _get_collaborators(self, uri):
         """Find artists that the given artist has collaborated with."""
@@ -73,7 +70,6 @@ class NetworkMiner():
                 collaborators.append(artist)
 
         return collaborators
-
 
     def _get_related_artists(
         self,
@@ -159,7 +155,6 @@ class NetworkMiner():
                 if len(explored) == self.max_pop_size:
                     raise RuntimeError("Maximum population size reached.")
 
-
     def _to_edgelist(self, connections, fname):
         """Write dictionary of connections to a NetworkX-compatible weighted edgelist."""
 
@@ -168,13 +163,11 @@ class NetworkMiner():
                 for related_arist in values:
                     f.write("{} {}\n".format(artist, related_arist))
 
-
     def _to_pickle(self, metadata, fname):
         """Pickle dictionary of metadata."""
 
         with open('{}/{}.pkl'.format('derivatives', fname), 'wb') as f:
             pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
-
 
     def write_edgelist(
         self,

--- a/search.py
+++ b/search.py
@@ -54,7 +54,7 @@ class NetworkMiner():
         return artist_metadata
 
 
-    def _get_collaborators(self, uri, attributes):
+    def _get_collaborators(self, uri):
         """Find artists that the given artist has collaborated with."""
 
         # Get the top tracks
@@ -109,8 +109,8 @@ class NetworkMiner():
 
             # Get up to `self.breadth_limit` collaborators and add unique artists to `related`
             if self.include_collaborators:
-                collaborators = self._get_collaborators(uri, attributes=attributes)
                 related_uri = [artist['uri'] for artist in related]
+                collaborators = self._get_collaborators(uri)
                 for artist in collaborators:
                     if artist['uri'] not in related_uri:
                         related.append(artist)

--- a/search.py
+++ b/search.py
@@ -148,7 +148,7 @@ class NetworkMiner():
 
                 # 5. Check if the max_pop_size has been hit
                 if len(explored) == self.max_pop_size:
-                    break
+                    raise RuntimeError("Maximum population size reached.")
 
 
     def _to_edgelist(self, connections, fname):
@@ -194,10 +194,11 @@ class NetworkMiner():
                 metadata,
                 attributes=attributes,
             )
+        except RuntimeError as error:
+            print(repr(error))
         except ConnectionError as error:
             print(repr(error))
             print("Saving current progress...")
-            pass
 
         # Save the outputs
         print("Saving edgelist...")

--- a/search.py
+++ b/search.py
@@ -87,6 +87,7 @@ class NetworkMiner():
         explored, queue = set(), [uri]
         explored.add(uri)
 
+        # While there are artists in the queue:
         while queue:
 
             # Get the leftmost artist in the queue
@@ -95,7 +96,7 @@ class NetworkMiner():
             # Add artist's attributes to metadata
             metadata[uri] = self._get_artist_metadata(uri, attributes=attributes)
             if self.verbose:
-                # Output looks like: "Node <NUMBER>: <ARTIST> (<POPULARITY>)"
+                # Verbose output: "Node <NUMBER>: <ARTIST> (<POPULARITY>)"
                 msg = "Node {}: {} (popularity = {})".format(
                     len(metadata.keys()),
                     metadata[uri]['name'],
@@ -103,13 +104,13 @@ class NetworkMiner():
                 )
                 print(msg)
 
-            # Get up to `self.breadth_limit` related artists and associated metadata, organized in a list
+            # Get up to `self.breadth_limit` related artists
             related = self.scrapper.artist_related_artists(uri)
             related = related['artists'][0:self.breadth_limit]
+            related_uri = [artist['uri'] for artist in related]
 
             # Get up to `self.breadth_limit` collaborators and add unique artists to `related`
             if self.include_collaborators:
-                related_uri = [artist['uri'] for artist in related]
                 collaborators = self._get_collaborators(uri)
                 for artist in collaborators:
                     if artist['uri'] not in related_uri:

--- a/search.py
+++ b/search.py
@@ -2,6 +2,8 @@ import pickle
 import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
 
+from requests.exceptions import ConnectionError
+
 
 class NetworkMiner():
 
@@ -192,8 +194,10 @@ class NetworkMiner():
                 metadata,
                 attributes=attributes,
             )
-        except RuntimeError as error:
+        except ConnectionError as error:
             print(repr(error))
+            print("Saving current progress...")
+            pass
 
         # Save the outputs
         print("Saving edgelist...")

--- a/search.py
+++ b/search.py
@@ -93,7 +93,7 @@ class NetworkMiner():
             metadata[uri] = self._get_artist_metadata(uri, attributes=attributes)
             if self.verbose:
                 # Verbose output: "Node <NUMBER>: <ARTIST> (<POPULARITY>)"
-                msg = "Node {}: {} (popularity = {})".format(
+                msg = "Node {}: {} ({})".format(
                     len(explored),
                     metadata[uri]['name'],
                     metadata[uri]['popularity']
@@ -144,7 +144,7 @@ class NetworkMiner():
                 queue.append(artist['uri'])
                 if self.verbose:
                     # Verbose output: "Node <NUMBER>: <ARTIST> (<POPULARITY>)"
-                    msg = "Node {}: {} (popularity = {})".format(
+                    msg = "Node {}: {} ({})".format(
                         len(explored),
                         metadata[related_artist_uri]['name'],
                         metadata[related_artist_uri]['popularity']


### PR DESCRIPTION
there is no parameter to limit how deep the search can go. when DFS is used, this is exploited and the network goes far away from the starting artist. 

to get a more complete view of the local network, we can use BFS instead

while BFS gives more detail at the local level, it doesn't get "zoom out" very far. a cross between DFS and BFS would be nice, but for now, BFS is the better option